### PR TITLE
Updated authorization URL

### DIFF
--- a/lib/passport-fitbit/strategy.js
+++ b/lib/passport-fitbit/strategy.js
@@ -44,7 +44,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.requestTokenURL = options.requestTokenURL || 'https://api.fitbit.com/oauth/request_token';
   options.accessTokenURL = options.accessTokenURL || 'https://api.fitbit.com/oauth/access_token';
-  options.userAuthorizationURL = options.userAuthorizationURL || 'https://api.fitbit.com/oauth/authorize';
+  options.userAuthorizationURL = options.userAuthorizationURL || 'https://www.fitbit.com/oauth/authorize';
   options.sessionKey = options.sessionKey || 'oauth:fitbit';
 
   OAuthStrategy.call(this, options, verify);


### PR DESCRIPTION
The Authorization URL was set to the incorrect subdomain. It should be www.fitbit.com.

For some reason, my second commit (incrementing the patch version) didn't come through. You'll need to also do that.