### PR TITLE
adding optional user auth parameters

### DIFF
--- a/lib/passport-fitbit/strategy.js
+++ b/lib/passport-fitbit/strategy.js
@@ -58,6 +58,28 @@ function Strategy(options, verify) {
 util.inherits(Strategy, OAuthStrategy);
 
 /**
+ * Return extra parameters to be included in the user authorization request.
+ *
+ * Fitbit allows 3 optional params to be included in the user auth request:
+ * locale=(en_US, de_DE, etc) this will force locale preference. 
+ * display=touch This forces a mobile friendly view
+ * requestCredentials=true This forces a login regardless of user 
+ *   already being logged in or not. Useful for sites that allow multiple
+ *   fitbit accounts to be connected to 1 user.
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+OAuthStrategy.prototype.userAuthorizationParams = function(options) {
+  var params = {};
+  if (options.locale) params.locale = options.locale;
+  if (options.mobile) params.display = 'touch';
+  if (options.requestCredentials) params.requestCredentials = 'true';
+  return params;
+}
+
+/**
  * Retrieve user profile from Fitbit.
  *
  * This function constructs a normalized profile, with the following properties:


### PR DESCRIPTION
I needed this for the mobile-friendly auth view, but noticed Fitbit allows more optional parameters than that so figured I would add then all.